### PR TITLE
Add `XLAStrategy` subclass to implement distributed utilities for torch-xla

### DIFF
--- a/image_segmentation/pytorch/runtime/distributed/test/test_xla_strategy.py
+++ b/image_segmentation/pytorch/runtime/distributed/test/test_xla_strategy.py
@@ -1,0 +1,37 @@
+import unittest
+
+import torch_xla.core.xla_model as xm
+from runtime.distributed.xla_strategy import XLAStrategy
+
+
+class TestXLAStrategy(unittest.TestCase):
+    """Smoke tests for XLAStrategy"""
+
+    def setUp(self):
+        """Initializes XLAStrategy object"""
+        self.xla_strategy = XLAStrategy()
+
+    def test_get_rank(self):
+        """Smoke test for get_rank"""
+        self.assertEqual(self.xla_strategy.get_rank(), xm.get_ordinal())
+
+    def test_get_world_size(self):
+        """Smoke test for get_world_size"""
+        self.assertEqual(self.xla_strategy.get_world_size(), xm.xrt_world_size())
+
+    def test_get_device(self):
+        """Smoke test for get_device"""
+        self.assertEqual(self.xla_strategy.get_device(0), xm.xla_device())
+
+    def test_seed_everything(self):
+        """Smoke test for seed_everything"""
+        seed = 1
+        self.xla_strategy.seed_everything(seed)
+        self.assertEqual(xm.get_rng_state(), seed)
+
+    def tearDown(self):
+        del self.xla_strategy
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/image_segmentation/pytorch/runtime/distributed/xla_strategy.py
+++ b/image_segmentation/pytorch/runtime/distributed/xla_strategy.py
@@ -1,0 +1,75 @@
+from typing import List
+
+import torch
+import torch_xla.core.xla_model as xm
+from runtime.distributed.distributed_strategy import DistributedStrategy
+
+
+class XLAStrategy(DistributedStrategy):
+    """Distributed utilities for PyTorch/XLA"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        world_size = xm.xrt_world_size()
+        if xm.is_master_ordinal():
+            print(f"torch-xla distributed initialized. World size: {world_size}")
+
+    def get_rank(self) -> int:
+        """Overrides DistributedStrategy.get_rank"""
+        rank = xm.get_ordinal()
+        return rank
+
+    def get_world_size(self) -> int:
+        """Overrides DistributedStrategy.get_world_size"""
+        world_size = xm.xrt_world_size()
+        return world_size
+
+    def get_device(self, local_rank: int) -> torch.device:
+        """Overrides DistributedStrategy.get_device"""
+        xla_device = xm.xla_device()
+        return xla_device
+
+    def barrier(self):
+        """Overrides DistributedStrategy.barrier"""
+        xm.rendezvous("barrier")
+
+    def seed_everything(self, seed: int):
+        """Overrides DistributedStrategy.seed_everything"""
+        xm.set_rng_state(seed)
+
+    def broadcast_seeds(self, seeds: List[int], device: torch.device) -> List[int]:
+        """Overrides DistributedStrategy.broadcast_seeds"""
+        if self.get_world_size() > 1:
+            seeds_tensor = torch.LongTensor(seeds).to(device)
+            self._broadcast(seeds_tensor, 0)
+            seeds = seeds_tensor.tolist()
+        return seeds
+
+    def reduce_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Overrides DistributedStrategy.reduce_tensor"""
+        world_size = self.get_world_size()
+        if world_size > 1:
+            rt = tensor.clone()
+            xm.all_reduce(
+                xm.REDUCE_SUM,
+                rt,
+            )
+            if rt.is_floating_point():
+                rt = rt / world_size
+            else:
+                rt = rt // world_size
+            return rt
+        return tensor
+
+    def _broadcast(self, tensor: torch.Tensor, source_rank: int):
+        # only broadcast when there are more than one process
+        if self.get_world_size() > 1:
+            # fill the worker tensors with zeros
+            if self.get_rank() != source_rank:
+                tensor.fill_(0)
+            # since only the master tensor is non-zero,
+            # all-reduce is equivalent to broadcast
+            xm.all_reduce(
+                reduce_type=xm.REDUCE_SUM,
+                inputs=tensor,
+            )

--- a/image_segmentation/pytorch/runtime/distributed/xla_strategy.py
+++ b/image_segmentation/pytorch/runtime/distributed/xla_strategy.py
@@ -10,24 +10,21 @@ class XLAStrategy(DistributedStrategy):
 
     def __init__(self) -> None:
         super().__init__()
-        world_size = xm.xrt_world_size()
+        world_size = self.get_world_size()
         if xm.is_master_ordinal():
             print(f"torch-xla distributed initialized. World size: {world_size}")
 
     def get_rank(self) -> int:
         """Overrides DistributedStrategy.get_rank"""
-        rank = xm.get_ordinal()
-        return rank
+        return xm.get_ordinal()
 
     def get_world_size(self) -> int:
         """Overrides DistributedStrategy.get_world_size"""
-        world_size = xm.xrt_world_size()
-        return world_size
+        return xm.xrt_world_size()
 
     def get_device(self, local_rank: int) -> torch.device:
         """Overrides DistributedStrategy.get_device"""
-        xla_device = xm.xla_device()
-        return xla_device
+        return xm.xla_device()
 
     def barrier(self):
         """Overrides DistributedStrategy.barrier"""

--- a/image_segmentation/pytorch/runtime/distributed/xla_strategy.py
+++ b/image_segmentation/pytorch/runtime/distributed/xla_strategy.py
@@ -50,7 +50,7 @@ class XLAStrategy(DistributedStrategy):
         world_size = self.get_world_size()
         if world_size > 1:
             rt = tensor.clone()
-            xm.all_reduce(
+            rt = xm.all_reduce(
                 xm.REDUCE_SUM,
                 rt,
             )


### PR DESCRIPTION
Resolve #3 

Related to:
- `DistributedStrategy` PR: https://github.com/thisisalbertliang/training/pull/4

We hope to refactor the `distributed_utils` module into a more readable and extensible `distributed` package.

The `distributed` package uses polymorphism (the base class is `DistributedStrategy` & the concrete sub-classes are `CUDAStrategy` and `XLAStrategy`) to toggle between CUDA and PT-XLA distributed utilities during runtime. The interface for all distributed ops is exposed via the `distributed_utils` module in the `distributed` package.

For more details, see b/224290413