### PR TITLE
Add `XLATrainer` subclass to implement UNet3D training in PyTorch/XLA

### DIFF
--- a/image_segmentation/pytorch/runtime/trainer/test/test_xla_trainer.py
+++ b/image_segmentation/pytorch/runtime/trainer/test/test_xla_trainer.py
@@ -1,0 +1,95 @@
+import unittest
+from argparse import Namespace
+
+import torch
+import torch_xla.core.xla_model as xm
+from data_loading.data_loader.unet3d_data_loader import get_data_loaders
+from model.losses import DiceCELoss, DiceScore
+from model.unet3d import Unet3D
+from runtime.distributed.distributed_utils import init_distributed
+from runtime.trainer.xla_trainer import XLATrainer
+
+
+class TestXLATrainer(unittest.TestCase):
+    """Smoke tests for XLATrainer"""
+
+    def setUp(self):
+        """Initializes XLATrainer object"""
+        self.batch_size = 1
+        self.image_size = (128, 128, 128)
+        flags = Namespace(
+            amp=False,
+            ga_steps=1,
+            layout="NCDHW",
+            include_background=False,
+            batch_size=self.batch_size,
+            input_shape=self.image_size,
+            val_input_shape=self.image_size,
+            benchmark=False,
+            num_workers=8,
+            optimizer="sgd",
+            learning_rate=0.8,
+            momentum=0.9,
+            weight_decay=0.0,
+            lr_decay_epochs=[],
+            lr_decay_factor=1.0,
+            loader="synthetic",
+            torch_xla=True,
+        )
+
+        init_distributed(flags)
+
+        model = Unet3D(
+            1,
+            3,
+            normalization="instancenorm",
+            activation="relu",
+        )
+
+        self.device = xm.xla_device()
+        train_loader, val_loader = get_data_loaders(
+            flags=flags,
+            num_shards=1,
+            global_rank=0,
+            device=self.device,
+        )
+
+        loss_fn = DiceCELoss(
+            to_onehot_y=True,
+            use_softmax=True,
+            layout=flags.layout,
+            include_background=flags.include_background,
+        )
+        score_fn = DiceScore(
+            to_onehot_y=True,
+            use_argmax=True,
+            layout=flags.layout,
+            include_background=flags.include_background,
+        )
+
+        self.xla_trainer = XLATrainer(
+            flags=flags,
+            model=model,
+            train_loader=train_loader,
+            val_loader=val_loader,
+            loss_fn=loss_fn,
+            score_fn=score_fn,
+            device=self.device,
+            callbacks=[],
+        )
+
+        input_size = (self.batch_size, 1) + self.image_size
+
+        self.image = torch.zeros(size=input_size, device=self.device)
+        self.label = torch.zeros_like(self.image, device=self.device)
+
+    def test_forward_pass(self):
+        """Smoke test for forward pass"""
+        loss_value = self.xla_trainer.forward_pass(self.image, self.label)
+
+        self.assertEqual(loss_value.size(), torch.Size([]))
+
+    def test_backward_pass(self):
+        """Smoke test for backward pass"""
+        loss_value = self.xla_trainer.forward_pass(self.image, self.label)
+        self.xla_trainer.backward_pass(iteration=0, loss_value=loss_value)

--- a/image_segmentation/pytorch/runtime/trainer/test/test_xla_trainer.py
+++ b/image_segmentation/pytorch/runtime/trainer/test/test_xla_trainer.py
@@ -33,7 +33,7 @@ class TestXLATrainer(unittest.TestCase):
             lr_decay_epochs=[],
             lr_decay_factor=1.0,
             loader="synthetic",
-            torch_xla=True,
+            device="xla",
         )
 
         init_distributed(self.flags)
@@ -59,8 +59,8 @@ class TestXLATrainer(unittest.TestCase):
         )
         self.input_size = (self.batch_size, 1) + self.image_size
 
-    def test_forward_and_backward_pass(self):
-        """Smoke test for forward & backward pass"""
+    def test_train_step(self):
+        """Smoke test for the forward pass, backward pass, and model weights update"""
         for num_workers in (1, 8):
             self.flags.num_workers = num_workers
 
@@ -85,8 +85,6 @@ class TestXLATrainer(unittest.TestCase):
             images = torch.zeros(size=self.input_size, device=self.device)
             labels = torch.zeros_like(images, device=self.device)
 
-            loss_value = xla_trainer.forward_pass(images, labels)
+            loss_value = xla_trainer.train_step(iteration=0, images=images, labels=labels)
 
             self.assertEqual(loss_value.size(), torch.Size([]))
-
-            xla_trainer.backward_pass(iteration=0, loss_value=loss_value)

--- a/image_segmentation/pytorch/runtime/trainer/test/test_xla_trainer.py
+++ b/image_segmentation/pytorch/runtime/trainer/test/test_xla_trainer.py
@@ -82,10 +82,10 @@ class TestXLATrainer(unittest.TestCase):
                 callbacks=[],
             )
 
-            image = torch.zeros(size=self.input_size, device=self.device)
-            label = torch.zeros_like(image, device=self.device)
+            images = torch.zeros(size=self.input_size, device=self.device)
+            labels = torch.zeros_like(images, device=self.device)
 
-            loss_value = xla_trainer.forward_pass(image, label)
+            loss_value = xla_trainer.forward_pass(images, labels)
 
             self.assertEqual(loss_value.size(), torch.Size([]))
 

--- a/image_segmentation/pytorch/runtime/trainer/xla_trainer.py
+++ b/image_segmentation/pytorch/runtime/trainer/xla_trainer.py
@@ -1,0 +1,97 @@
+import torch
+import torch_xla.amp
+import torch_xla.amp.grad_scaler
+import torch_xla.amp.syncfree
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.parallel_loader as pl
+from runtime.trainer.unet3d_trainer import UNet3DTrainer
+
+
+class XLATrainer(UNet3DTrainer):
+    """Trains UNet3D in PyTorch/XLA"""
+
+    def __init__(
+        self,
+        flags,
+        model,
+        train_loader,
+        val_loader,
+        loss_fn,
+        score_fn,
+        device,
+        callbacks,
+    ) -> None:
+        super().__init__(
+            flags, model, train_loader, val_loader, loss_fn, score_fn, device, callbacks
+        )
+        assert isinstance(self.train_loader, pl.MpDeviceLoader), (
+            "training data loader for XLATrainer must be an instance of "
+            "torch_xla.distributed.parallel_loader.MpDeviceLoader"
+        )
+        assert isinstance(self.val_loader, pl.MpDeviceLoader), (
+            "validation data loader for XLATrainer must be an instance of "
+            "torch_xla.distributed.parallel_loader.MpDeviceLoader"
+        )
+
+        # Setup grad scaler and autocast
+        self.scaler: torch_xla.amp.GradScaler = torch_xla.amp.grad_scaler.GradScaler()
+
+        # Setup train sampler
+        self.train_sampler = self.train_loader._loader.sampler
+
+        # Get hardware type
+        self.hw_type = xm.xla_device_hw(self.device)
+
+    def forward_pass(self, image: torch.Tensor, label: torch.Tensor) -> torch.Tensor:
+        """Overrides UNet3DTrainer.forward_pass"""
+        with torch_xla.amp.autocast(enabled=self.flags.amp):
+            output = self.model(image)
+            if self.hw_type == "GPU":
+                # currently, running torch-xla on GPU requires sandwiching
+                # the loss value computation in between mark_step, otherwise
+                # the CUDA memory will be corrupted
+                # this is a temporary solution, and these two mark_step will
+                # be removed once this memory corruption bug is resolved in torch-xla
+                xm.mark_step()
+            loss_value = self.loss_fn(output, label)
+            if self.hw_type == "GPU":
+                xm.mark_step()
+            loss_value /= self.flags.ga_steps
+
+        return loss_value
+
+    def backward_pass(self, iteration: int, loss_value: torch.Tensor):
+        """Overrides UNet3DTrainer.backward_pass"""
+        if self.flags.amp:
+            self.scaler.scale(loss_value).backward()
+        else:
+            loss_value.backward()
+
+        if (iteration + 1) % self.flags.ga_steps == 0:
+            if self.flags.amp:
+                self.scaler.step(self.optimizer)
+                self.scaler.update()
+            else:
+                xm.optimizer_step(self.optimizer)
+
+    @staticmethod
+    def get_optimizer(params, flags):
+        """Overrides UNet3DTrainer.get_optimizer"""
+        if flags.amp:
+            if flags.optimizer == "adam":
+                optim = torch_xla.amp.syncfree.Adam(
+                    params, lr=flags.learning_rate, weight_decay=flags.weight_decay
+                )
+            elif flags.optimizer == "sgd":
+                optim = torch_xla.amp.syncfree.SGD(
+                    params,
+                    lr=flags.learning_rate,
+                    momentum=flags.momentum,
+                    nesterov=True,
+                    weight_decay=flags.weight_decay,
+                )
+            else:
+                raise ValueError(f"Optimizer {flags.optimizer} is not supported for torch-xla amp")
+            return optim
+        else:
+            return UNet3DTrainer.get_optimizer(params, flags)


### PR DESCRIPTION
Resolve #8 (partially)

Related to:
- `UNet3DTrainer` PR: https://github.com/thisisalbertliang/training/pull/9

We hope to refactor the `training` module into a more readable and extensible `trainer` package.

The `trainer` package uses polymorphism (the base class is `UNet3DTrainer` & the concrete sub-classes are `CUDATrainer` and `XLATrainer`) to toggle between training with CUDA and training with PT-XLA during runtime.

For more details, see b/224290413