### PR TITLE
Add `get_trainer` method as a factory for `UNet3DTrainer`

### DIFF
--- a/image_segmentation/pytorch/runtime/trainer/trainer_factory.py
+++ b/image_segmentation/pytorch/runtime/trainer/trainer_factory.py
@@ -4,12 +4,14 @@ from runtime.trainer.xla_trainer import XLATrainer
 
 def get_trainer(flags, model, train_loader, val_loader, loss_fn, score_fn, device, callbacks):
     """Initializes and return the trainer (XLATrainer or CUDATrainer)"""
-    if flags.torch_xla:
+    if flags.device == "xla":
         trainer = XLATrainer(
             flags, model, train_loader, val_loader, loss_fn, score_fn, device, callbacks
         )
-    else:
+    elif flags.device == "cuda":
         trainer = CUDATrainer(
             flags, model, train_loader, val_loader, loss_fn, score_fn, device, callbacks
         )
+    else:
+        raise ValueError(f"Device {flags.device} unknown. Valid devices are: cuda, xla")
     return trainer

--- a/image_segmentation/pytorch/runtime/trainer/trainer_factory.py
+++ b/image_segmentation/pytorch/runtime/trainer/trainer_factory.py
@@ -1,0 +1,15 @@
+from runtime.trainer.cuda_trainer import CUDATrainer
+from runtime.trainer.xla_trainer import XLATrainer
+
+
+def get_trainer(flags, model, train_loader, val_loader, loss_fn, score_fn, device, callbacks):
+    """Initializes and return the trainer (XLATrainer or CUDATrainer)"""
+    if flags.torch_xla:
+        trainer = XLATrainer(
+            flags, model, train_loader, val_loader, loss_fn, score_fn, device, callbacks
+        )
+    else:
+        trainer = CUDATrainer(
+            flags, model, train_loader, val_loader, loss_fn, score_fn, device, callbacks
+        )
+    return trainer


### PR DESCRIPTION
Resolve #8 (partially)

We hope to refactor the `training` module into a more readable and extensible `trainer` package.

The `trainer` package uses polymorphism (the base class is `UNet3DTrainer` & the concrete sub-classes are `CUDATrainer` and `XLATrainer`) to toggle between training with CUDA and training with PT-XLA during runtime.

This `get_trainer` method acts as a factory for instantiating `UNet3DTrainer` objects.

For more details, see b/224290413