### PR TITLE
Add `cuda_data_loader` module to encapsulate creation of `DataLoader` objects for PyTorch CUDA

### DIFF
--- a/image_segmentation/pytorch/data_loading/data_loader/cuda_data_loader.py
+++ b/image_segmentation/pytorch/data_loading/data_loader/cuda_data_loader.py
@@ -1,0 +1,51 @@
+from argparse import Namespace
+from typing import Tuple
+
+from torch.utils.data import DataLoader, Dataset
+from torch.utils.data.distributed import DistributedSampler
+
+
+def get_data_loaders(
+    flags: Namespace,
+    num_shards: int,
+    train_dataset: Dataset,
+    val_dataset: Dataset,
+) -> Tuple[DataLoader, DataLoader]:
+    """
+    Initializes and returns (train_data_loader, val_data_loader) as Dataloader objects
+
+    :param Namespace flags: the runtime arguments
+    :param int num_shards: number of shards for the train dataset
+    :param Dataset train_dataset: the train dataset
+    :param Dataset val_dataset: the validation dataset
+    :return: the tuple (train_loader, val_loader)
+    :rtype: Tuple[DataLoader, DataLoader]
+    """
+    if num_shards > 1:
+        # train sampler for data parallelism
+        train_sampler = DistributedSampler(train_dataset, seed=flags.seed, drop_last=True)
+    else:
+        train_sampler = None
+
+    val_sampler = None
+
+    train_dataloader = DataLoader(
+        train_dataset,
+        batch_size=flags.batch_size,
+        shuffle=not flags.benchmark and train_sampler is None,
+        sampler=train_sampler,
+        num_workers=flags.num_workers,
+        pin_memory=True,
+        drop_last=True,
+    )
+    val_dataloader = DataLoader(
+        val_dataset,
+        batch_size=1,
+        shuffle=not flags.benchmark and val_sampler is None,
+        sampler=val_sampler,
+        num_workers=flags.num_workers,
+        pin_memory=True,
+        drop_last=False,
+    )
+
+    return train_dataloader, val_dataloader

--- a/image_segmentation/pytorch/data_loading/data_loader/cuda_data_loader.py
+++ b/image_segmentation/pytorch/data_loading/data_loader/cuda_data_loader.py
@@ -11,8 +11,7 @@ def get_data_loaders(
     train_dataset: Dataset,
     val_dataset: Dataset,
 ) -> Tuple[DataLoader, DataLoader]:
-    """
-    Initializes and returns (train_data_loader, val_data_loader) as Dataloader objects
+    """Initializes and returns (train_data_loader, val_data_loader) as Dataloader objects
 
     :param Namespace flags: the runtime arguments
     :param int num_shards: number of shards for the train dataset


### PR DESCRIPTION
Resolve #13 (partially)

Related to
- https://github.com/thisisalbertliang/training/pull/14

We hope to refactor the `data_loading` module into a more readable and extensible `data_loader` package.

The `data_loader` package provides a common interface (i.e. `unet3d_data_loader.get_data_loaders`) for retrieving the data loaders for PyTorch CUDA and PyTorch/XLA respectively. It encapsulates the logic for creating the `pl.MpDeviceLoader` objects in the `xla_data_loader` module and encapsulates the logic for creating the `torch.utils.data.DataLoader` objects in the `cuda_data_loader` module.

For more details, see b/224290413