### PR TITLE
Add `xla_data_loader` module to encapsulate creation of` pl.MpDeviceLoader` objects for PyTorch/XLA

### DIFF
--- a/image_segmentation/pytorch/data_loading/data_loader/test/test_xla_data_loader.py
+++ b/image_segmentation/pytorch/data_loading/data_loader/test/test_xla_data_loader.py
@@ -1,0 +1,55 @@
+import unittest
+from argparse import Namespace
+
+import data_loading.data_loader.xla_data_loader as xl
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.parallel_loader as pl
+from data_loading.data_loader.unet3d_data_loader import SyntheticDataset
+
+
+class TestXLADataLoader(unittest.TestCase):
+    """Smoke test for data_loading.data_loader.xla_data_loader"""
+
+    def setUp(self):
+        """Initializes arguments to get_data_loaders"""
+        self.flags = Namespace(
+            seed=0,
+            batch_size=1,
+            benchmark=False,
+            num_workers=4,
+            input_shape=(128, 128, 128),
+            layout="NCDHW",
+        )
+        self.num_shards = 1
+        self.global_rank = 0
+        self.device = xm.xla_device()
+        self.train_dataset = SyntheticDataset(
+            scalar=True,
+            shape=self.flags.input_shape,
+            layout=self.flags.layout,
+        )
+        self.val_dataset = SyntheticDataset(
+            scalar=True,
+            shape=self.flags.input_shape,
+            layout=self.flags.layout,
+        )
+
+    def test_get_data_loaders(self):
+        """Smoke test for get_data_loaders"""
+        train_loader, val_loader = xl.get_data_loaders(
+            flags=self.flags,
+            num_shards=self.num_shards,
+            global_rank=self.global_rank,
+            device=self.device,
+            train_dataset=self.train_dataset,
+            val_dataset=self.val_dataset,
+        )
+
+        self.assertTrue(isinstance(train_loader, pl.MpDeviceLoader))
+        self.assertTrue(isinstance(val_loader, pl.MpDeviceLoader))
+
+        self.assertEqual(train_loader._device, self.device)
+        self.assertEqual(val_loader._device, self.device)
+
+        self.assertEqual(len(train_loader), 64)
+        self.assertEqual(len(val_loader), 64)

--- a/image_segmentation/pytorch/data_loading/data_loader/xla_data_loader.py
+++ b/image_segmentation/pytorch/data_loading/data_loader/xla_data_loader.py
@@ -1,0 +1,66 @@
+from argparse import Namespace
+from typing import Tuple
+
+import torch
+import torch_xla.distributed.parallel_loader as pl
+from torch.utils.data import DataLoader, Dataset
+from torch.utils.data.distributed import DistributedSampler
+
+
+def get_data_loaders(
+    flags: Namespace,
+    num_shards: int,
+    global_rank: int,
+    device: torch.device,
+    train_dataset: Dataset,
+    val_dataset: Dataset,
+) -> Tuple[pl.MpDeviceLoader, pl.MpDeviceLoader]:
+    """
+    Initializes and returns (train_data_loader, val_data_loader) as MpDeviceLoader objects
+
+    :param Namespace flags: the runtime arguments
+    :param int num_shards: number of shards for the train dataset
+    :param int global_rank: global rank associated with the device
+    :param torch.device device: the device to use for MpDeviceLoader
+    :param Dataset train_dataset: the train dataset
+    :param Dataset val_dataset: the validation dataset
+    :return: the tuple (train_loader, val_loader)
+    :rtype: Tuple[pl.MpDeviceLoader, pl.MpDeviceLoader]
+    """
+    if num_shards > 1:
+        # train sampler for data parallelism
+        train_sampler = DistributedSampler(
+            train_dataset,
+            num_replicas=num_shards,
+            rank=global_rank,
+            seed=flags.seed,
+            drop_last=True,
+        )
+    else:
+        train_sampler = None
+
+    val_sampler = None
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=flags.batch_size,
+        shuffle=not flags.benchmark and train_sampler is None,
+        sampler=train_sampler,
+        num_workers=flags.num_workers,
+        pin_memory=False,
+        drop_last=True,
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=1,
+        shuffle=not flags.benchmark and val_sampler is None,
+        sampler=val_sampler,
+        num_workers=flags.num_workers,
+        pin_memory=False,
+        drop_last=False,
+    )
+
+    train_loader = pl.MpDeviceLoader(train_loader, device)
+    val_loader = pl.MpDeviceLoader(val_loader, device)
+
+    return train_loader, val_loader

--- a/image_segmentation/pytorch/data_loading/data_loader/xla_data_loader.py
+++ b/image_segmentation/pytorch/data_loading/data_loader/xla_data_loader.py
@@ -15,8 +15,7 @@ def get_data_loaders(
     train_dataset: Dataset,
     val_dataset: Dataset,
 ) -> Tuple[pl.MpDeviceLoader, pl.MpDeviceLoader]:
-    """
-    Initializes and returns (train_data_loader, val_data_loader) as MpDeviceLoader objects
+    """Initializes and returns (train_data_loader, val_data_loader) as MpDeviceLoader objects
 
     :param Namespace flags: the runtime arguments
     :param int num_shards: number of shards for the train dataset


### PR DESCRIPTION
Resolve #13 (partially)

Related to
- https://github.com/thisisalbertliang/training/pull/14

We hope to refactor the `data_loading` module into a more readable and extensible `data_loader` package.

The `data_loader` package provides a common interface (i.e. `unet3d_data_loader.get_data_loaders`) for retrieving the data loaders for PyTorch CUDA and PyTorch/XLA respectively. It encapsulates the logic for creating the `pl.MpDeviceLoader` objects in the `xla_data_loader` module and encapsulates the logic for creating the `torch.utils.data.DataLoader` objects in the `cuda_data_loader` module.

For more details, see b/224290413